### PR TITLE
UI: hide KusionStack title in the navbar since the logo is already here

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -100,6 +100,10 @@ html[data-theme='dark'] {
   background-color: rgb(66 66 66 / 30%);
 }
 
+.navbar__title {
+  display: none;
+}
+
 .header-github-link:hover {
   opacity: 0.6;
 }


### PR DESCRIPTION
hide the redundant KusionStack title from navbar:
before:
![image](https://github.com/KusionStack/kusionstack.io/assets/29722609/a32e5c9c-ed5b-4122-ac3e-28feff89f89f)

after:
![image](https://github.com/KusionStack/kusionstack.io/assets/29722609/dcc9eda1-6986-4620-a61a-c719571109c6)
