### PR TITLE
fix: wrong blog link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -99,7 +99,12 @@ const config = {
                         label: 'Governance',
                     },
 
-                    { to: 'https://medium.com/@kusionstack', label: 'Blog', position: 'left' },
+                    {
+                        to: 'https://medium.com/@kusionstack',
+                        label: 'Blog',
+                        position: 'left',
+                        target: '_self'
+                    },
 
                     //{
                     //  type: 'docsVersionDropdown',


### PR DESCRIPTION
Purpose:
* Fix wrong blog link, target from `_blank` to `_self`