### PR TITLE
fix(docs): sed syntax fix for GNU sed

### DIFF
--- a/karpor_versioned_docs/version-v0.5/3-user-guide/1-how-to-create-token.md
+++ b/karpor_versioned_docs/version-v0.5/3-user-guide/1-how-to-create-token.md
@@ -15,10 +15,20 @@ kubectl get configmap karpor-kubeconfig -n karpor -o go-template='{{.data.config
 
 **Note**: Please ensure that the server address in the Hub Cluster's KubeConfig is accessible from your local machine. The default address is the internal cluster address (https://karpor-server.karpor.svc:7443), which cannot be directly connected from local. If you deployed Karpor in a local cluster, you need to forward the karpor-server service to local port 7443 and change the server address to `https://127.0.0.1:7443`.
 
-You can use the following command to change the access address in the Hub Cluster certificate to the local address (Windows users need to replace manually):
+You can use the following sed command to change the access address in the Hub Cluster certificate to the local address:
+
+For MacOS/BSD systems (need an extra `''` after `-i`):  
 ```shell
 sed -i '' 's/karpor-server.karpor.svc/127.0.0.1/g' $HOME/.kube/karpor-hub-cluster.kubeconfig
 ```
+
+For Linux systems (only `-i`):  
+```shell
+sed -i 's/karpor-server.karpor.svc/127.0.0.1/g' $HOME/.kube/karpor-hub-cluster.kubeconfig
+```
+
+For Windows:  
+need to proceed manually
 
 ## Forward the Services of the Hub Cluster to the Local Machine
 


### PR DESCRIPTION
the initial command only works for the BSD variant of sed (MacOS..)   A syntax error is raised for the GNU variant  
need to remove the extra backup `''` after `-i`   

on OpenSuse tumbleweed:  
Using the initial command gives   

``` shell
 $ sed -i '' 's/karpor-server.karpor.svc/127.0.0.1/g' $HOME/.kube/karpor-hub-cluster.kubeconfig
sed: can't read s/karpor-server.karpor.svc/127.0.0.1/g: No such file or directory

```

and after the fix, it works

for reference : https://www.baeldung.com/linux/gnu-bsd-stream-editor

<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

user guide docs  
https://www.kusionstack.io/karpor/user-guide/how-to-create-token

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note. - 

> provided link for release-policy not working

```release-note
bugfix
```
